### PR TITLE
in case connection is not established we don't need to close the socket

### DIFF
--- a/src/gearman_connection.erl
+++ b/src/gearman_connection.erl
@@ -92,13 +92,7 @@ handle_info(Info,  State) ->
 
 terminate(Reason, #state{socket=Socket}) ->
     error_logger:error_msg("stopping: ~p", [Reason]),
-    case Socket of
-        not_connected ->
-            void;
-        _ ->
-            gen_tcp:close(Socket)
-    end,
-    ok.
+    close_socket(Socket).
 
 handle_cast(stop, State) ->
     {stop, normal, State}.
@@ -109,9 +103,11 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 disconnect_state(State) ->
     State#state.pidparent ! {self(), disconnected},
-    gen_tcp:close(State#state.socket),
+    close_socket(State#state.socket),
     State#state{socket=not_connected, buffer=[]}.
 
+close_socket(not_connected) -> ok;
+close_socket(Socket)        -> gen_tcp:close(Socket).
 
 handle_command(State, NewData) ->
 	Packet = list_to_binary([State#state.buffer, NewData]),


### PR DESCRIPTION
Solves certain error scenario's. Like:

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in :inet.tcp_close/1
        (kernel) inet.erl:1618: :inet.tcp_close(:not_connected)
        (erlang_gearman) src/gearman_connection.erl:112: :gearman_connection.disconnect_state/1
        (erlang_gearman) src/gearman_connection.erl:62: :gearman_connection.handle_call/3
        (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
        (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
```